### PR TITLE
feat: migrate to PaperMod theme with Pretext excerpts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ shorturl.ps1
 public/
 resources/
 .worktrees/
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ shorturl.ps1
 .dccache
 public/
 resources/
+.worktrees/

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = themes/blowfish
 	url = https://github.com/nunocoracao/blowfish.git
 	branch = main
+[submodule "themes/PaperMod"]
+	path = themes/PaperMod
+	url = https://github.com/adityatelange/hugo-PaperMod.git

--- a/assets/css/extended/pretext.css
+++ b/assets/css/extended/pretext.css
@@ -1,0 +1,16 @@
+[data-pretext-card="true"] {
+  display: flex;
+  flex-direction: column;
+}
+
+[data-pretext-card="true"] .entry-content {
+  flex: 1;
+}
+
+[data-pretext-scope="excerpt"] {
+  --pretext-height: auto;
+}
+
+[data-pretext-scope="excerpt"][data-pretext-ready="true"] {
+  min-height: var(--pretext-height);
+}

--- a/assets/css/extended/site-overrides.css
+++ b/assets/css/extended/site-overrides.css
@@ -1,0 +1,43 @@
+#TableOfContents {
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+#TableOfContents ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+#TableOfContents ul ul {
+  padding-left: 0.75rem;
+  border-left: 1px solid var(--border);
+  margin-left: 0.5rem;
+}
+
+#TableOfContents li {
+  margin: 0.15rem 0;
+}
+
+#TableOfContents a {
+  display: block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  color: var(--secondary);
+  text-decoration: none;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  transition: all 0.15s ease;
+  border-left: 2px solid transparent;
+}
+
+#TableOfContents a:hover,
+#TableOfContents a.active {
+  color: var(--primary);
+  background: var(--tertiary);
+  border-left-color: var(--primary);
+}
+
+.post-ads {
+  margin: 1.5rem 0;
+}

--- a/assets/js/pretext-enhance.js
+++ b/assets/js/pretext-enhance.js
@@ -1,0 +1,33 @@
+import { prepare, layout } from '@chenglou/pretext'
+import { PRETEXT_SCOPES, markReady, readFont, readLineHeight } from './pretext-targets.js'
+
+function enhanceExcerpt(element) {
+  const width = element.clientWidth
+
+  if (!width) {
+    return
+  }
+
+  const text = element.textContent?.trim()
+
+  if (!text) {
+    return
+  }
+
+  const prepared = prepare(text, readFont(element))
+  const metrics = layout(prepared, width, readLineHeight(element))
+
+  markReady(element, metrics)
+}
+
+function runEnhancements() {
+  document.querySelectorAll(PRETEXT_SCOPES.excerpt).forEach(enhanceExcerpt)
+}
+
+let resizeTimer = 0
+
+window.addEventListener('load', runEnhancements, { once: true })
+window.addEventListener('resize', () => {
+  window.clearTimeout(resizeTimer)
+  resizeTimer = window.setTimeout(runEnhancements, 150)
+})

--- a/assets/js/pretext-targets.js
+++ b/assets/js/pretext-targets.js
@@ -1,0 +1,30 @@
+export const PRETEXT_SCOPES = {
+  excerpt: '[data-pretext-scope="excerpt"]',
+}
+
+export function readFont(element) {
+  const style = window.getComputedStyle(element)
+  return [
+    style.fontStyle,
+    style.fontWeight,
+    style.fontSize,
+    style.fontFamily,
+  ].join(' ')
+}
+
+export function readLineHeight(element) {
+  const style = window.getComputedStyle(element)
+  const parsed = Number.parseFloat(style.lineHeight)
+
+  if (!Number.isNaN(parsed)) {
+    return parsed
+  }
+
+  return Number.parseFloat(style.fontSize) * 1.4
+}
+
+export function markReady(element, metrics) {
+  element.dataset.pretextReady = 'true'
+  element.style.setProperty('--pretext-height', `${metrics.height}px`)
+  element.style.setProperty('--pretext-lines', `${metrics.lineCount}`)
+}

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -1,7 +1,4 @@
-# -- Site Configuration --
-# https://blowfish.page/docs/getting-started/
-
-theme = "blowfish"
+theme = "PaperMod"
 baseURL = "https://classroom.anir0y.in/"
 defaultContentLanguage = "en"
 
@@ -16,17 +13,9 @@ buildExpired = false
 [pagination]
   pagerSize = 10
 
-[imaging]
-  anchor = 'Center'
-
 [taxonomies]
   tag = "tags"
   category = "categories"
-
-[sitemap]
-  changefreq = 'daily'
-  filename = 'sitemap.xml'
-  priority = 0.5
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]
@@ -34,25 +23,3 @@ buildExpired = false
 [minify]
   disableXML = true
   minifyOutput = true
-
-[related]
-  threshold = 0
-  toLower = false
-
-    [[related.indices]]
-        name = "tags"
-        weight = 100
-
-    [[related.indices]]
-        name = "categories"
-        weight = 100
-
-    [[related.indices]]
-        name = "date"
-        weight = 10
-
-    [[related.indices]]
-      applyFilter = false
-      name = 'fragmentrefs'
-      type = 'fragments'
-      weight = 10

--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -1,5 +1,3 @@
-# -- Main Menu --
-
 [[main]]
   name = "Posts"
   pageRef = "post"
@@ -21,18 +19,11 @@
   weight = 40
 
 [[main]]
-  name = "About"
-  url = "/about/me/"
+  name = "Search"
+  url = "/search/"
   weight = 50
 
-# -- Footer Menu --
-
-[[footer]]
-  name = "Tags"
-  pageRef = "tags"
-  weight = 10
-
-[[footer]]
-  name = "Categories"
-  pageRef = "categories"
-  weight = 20
+[[main]]
+  name = "About"
+  url = "/about/me/"
+  weight = 60

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,94 +1,49 @@
-# -- Theme Parameters --
-# https://blowfish.page/docs/configuration/#theme-parameters
+env = "production"
+defaultTheme = "auto"
+disableThemeToggle = false
+ShowReadingTime = true
+ShowShareButtons = true
+ShowPostNavLinks = true
+ShowBreadCrumbs = true
+ShowCodeCopyButtons = true
+ShowRssButtonInSectionTermList = true
+UseHugoToc = true
+disableScrollToTop = false
+hidemeta = false
+hideSummary = false
+showtoc = true
+tocopen = false
 
-colorScheme = "ocean"
-defaultAppearance = "dark"
-autoSwitchAppearance = true
+[assets]
+  favicon = "/img/avatar.jpeg"
+  favicon16x16 = "/img/avatar.jpeg"
+  favicon32x32 = "/img/avatar.jpeg"
+  apple_touch_icon = "/img/avatar.jpeg"
 
-enableSearch = true
-enableCodeCopy = true
+[label]
+  text = "Classroom"
+  icon = "/img/avatar.jpeg"
+  iconHeight = 35
 
-disableImageOptimization = false
-disableTextInHeader = false
-hotlinkFeatureImage = true
+[homeInfoParams]
+  Title = "Animesh Roy's Classroom"
+  Content = "Cybersecurity expertise - CTF walkthroughs, malware analysis, penetration testing, and security research."
 
-highlightCurrentMenuArea = true
-smartTOC = true
-smartTOCHideUnfocusedChildren = true
+[cover]
+  hidden = false
+  hiddenInList = false
+  hiddenInSingle = false
 
-# SEO
-defaultSocialImage = "img/cover.jpg"
-enableStructuredBreadcrumbs = true
+[editPost]
+  URL = "https://github.com/anir0y/classroom/tree/master/content"
+  Text = "Suggest Changes"
+  appendFilePath = true
 
-[header]
-  layout = "basic"
-
-[footer]
-  showMenu = true
-  showCopyright = true
-  showThemeAttribution = true
-  showAppearanceSwitcher = true
-  showScrollToTop = true
-
-[homepage]
-  layout = "background"
-  homepageImage = "img/cover.jpg"
-  showRecent = true
-  showRecentItems = 10
-  showMoreLink = true
-  showMoreLinkDest = "/post/"
-  cardView = true
-  cardViewScreenWidth = false
-  layoutBackgroundBlur = true
-
-[article]
-  showDate = true
-  showDateUpdated = true
-  showAuthor = true
-  showHero = true
-  heroStyle = "background"
-  layoutBackgroundBlur = true
-  layoutBackgroundHeaderSpace = true
-  showBreadcrumbs = true
-  showDraftLabel = true
-  showEdit = false
-  showHeadingAnchors = true
-  showPagination = true
-  showReadingTime = true
-  showTableOfContents = true
-  showRelatedContent = true
-  relatedContentLimit = 3
-  showTaxonomies = true
-  showWordCount = true
-  showZenMode = false
-
-[list]
-  showHero = true
-  heroStyle = "background"
-  layoutBackgroundBlur = true
-  layoutBackgroundHeaderSpace = true
-  showBreadcrumbs = false
-  showSummary = true
-  showTableOfContents = false
-  showCards = true
-  groupByYear = true
-  cardView = true
-  cardViewScreenWidth = false
-
-[sitemap]
-  excludedKinds = ["taxonomy", "term"]
-
-[taxonomy]
-  showTermCount = true
-  showHero = false
-  showBreadcrumbs = false
-  showTableOfContents = false
-  cardView = true
-
-[term]
-  showHero = false
-  showBreadcrumbs = false
-  showTableOfContents = true
-  groupByYear = false
-  cardView = true
-  cardViewScreenWidth = false
+[fuseOpts]
+  isCaseSensitive = false
+  shouldSort = true
+  location = 0
+  distance = 1000
+  threshold = 0.4
+  minMatchCharLength = 0
+  keys = ["title", "permalink", "summary", "content"]

--- a/content/search.md
+++ b/content/search.md
@@ -1,0 +1,5 @@
++++
+title = "Search"
+layout = "search"
+summary = "Search the Classroom archive"
++++

--- a/docs/superpowers/specs/2026-04-15-papermod-pretext-design.md
+++ b/docs/superpowers/specs/2026-04-15-papermod-pretext-design.md
@@ -1,0 +1,123 @@
+# PaperMod + Pretext Design
+
+## Problem
+
+The site should switch to PaperMod while also improving text rendering quality across article pages, homepage/list excerpts, and headings. The new typography layer must not sacrifice the site's static-site strengths such as SEO, accessibility, and readable no-JavaScript output.
+
+## Proposed Approach
+
+Use a hybrid architecture:
+
+1. Reapply PaperMod as the base Hugo theme.
+2. Keep Hugo-rendered HTML as the canonical text output.
+3. Add a repo-owned Pretext enhancement layer that progressively improves selected text regions after page load.
+4. Scope Pretext to marked regions only, so the baseline PaperMod site remains fully usable if the enhancement layer never runs.
+
+## Scope
+
+In scope:
+
+- Install and activate PaperMod as the site theme.
+- Preserve repo-owned SEO, schema, ad, comment, and publisher integrations.
+- Add a repo-owned Pretext asset/module for progressive enhancement.
+- Enhance three text surfaces over time: headings, homepage/list excerpts, and article body content.
+- Add template hooks and CSS needed to opt specific regions into Pretext enhancement.
+
+Out of scope:
+
+- Replacing canonical article HTML with client-rendered text.
+- Rewriting markdown content.
+- Introducing a full SPA or app framework.
+- Unrelated visual redesign beyond what PaperMod and the typography enhancement require.
+
+## Architecture
+
+The system should have three layers:
+
+- **Theme layer:** PaperMod owns the base templates, assets, and default styling.
+- **Content layer:** Hugo content, front matter, and repo-owned metadata remain the source of truth.
+- **Enhancement layer:** A small repo-owned Pretext module progressively enhances selected rendered text regions in the browser.
+
+The enhancement layer must sit on top of, not replace, the HTML produced by Hugo. This preserves search indexing, semantic markup, and a readable no-JavaScript baseline.
+
+## Components
+
+### 1. PaperMod Integration
+
+PaperMod becomes the active theme source and base template set. Repo-owned hooks and overrides adapt current site behavior to PaperMod's structure.
+
+### 2. Enhancement Asset Module
+
+A repo-owned JavaScript entrypoint initializes Pretext only on pages that expose marked text regions. This module should avoid global rewrites and only touch the regions explicitly tagged for enhancement.
+
+### 3. Template Hook Layer
+
+Hugo partials and layout overrides should expose enhancement targets via stable classes or data attributes for:
+
+- headings / titles
+- homepage and list card excerpts
+- article body content
+
+These markers should be readable and safe even when no JavaScript runs.
+
+### 4. Enhancement Styles
+
+Repo-owned CSS should style enhanced regions only after successful initialization. The CSS must cooperate with PaperMod rather than fork the entire theme's typography stack.
+
+## Data Flow
+
+1. Hugo renders the site into normal HTML.
+2. PaperMod styles the page and repo-owned template hooks mark eligible text regions.
+3. The Pretext module scans only marked regions after load.
+4. Pretext measures and applies enhancement behavior to those regions.
+5. If enhancement fails or is skipped, the page continues using the original PaperMod-rendered HTML.
+
+## Error Handling
+
+Pretext must be non-critical. Failure cases should degrade to the default PaperMod output without:
+
+- blank text
+- hidden text that never reappears
+- broken page flow
+- dependency on client-side hydration for readable content
+
+Enhancement should be opt-in by region and guarded by initialization checks so unsupported pages stay untouched.
+
+## Validation
+
+The implementation is correct when:
+
+- Hugo builds successfully with PaperMod active.
+- JS-disabled pages still render readable headings, excerpts, and article content.
+- Marked regions enhance correctly when the Pretext module is present.
+- SEO, schema, ad, comment, and publisher integrations still render in the intended places.
+- Homepage, list pages, and single article pages remain readable and stable.
+
+## Testing Strategy
+
+Testing should cover both baselines:
+
+1. **Static baseline:** Hugo build and rendered HTML checks with enhancement disabled or absent.
+2. **Enhanced baseline:** browser-level verification that marked regions initialize cleanly and do not regress readability or layout stability.
+
+Validation should focus first on titles/excerpts, then article body content.
+
+## Risks
+
+- Pretext introduces a repo-owned client-side asset path into a mostly static Hugo site.
+- Theme migration and typography enhancement together increase integration complexity.
+- Some article-body enhancements may be harder to make robust than title/excerpt enhancements.
+
+## Risk Mitigation
+
+- Roll out enhancement in phases instead of enabling every surface at once.
+- Keep Hugo HTML as the fallback source of truth.
+- Limit Pretext to explicitly marked regions.
+- Keep theme migration and enhancement wiring separated in repo-owned files so failures are easier to isolate.
+
+## Success Criteria
+
+- The site runs on PaperMod.
+- Repo-owned SEO and monetization integrations still work.
+- Pretext progressively enhances headings, excerpts, and article text without becoming required for readability.
+- The implementation leaves a clear separation between theme code and repo-owned enhancement code.

--- a/docs/superpowers/specs/2026-04-15-papermod-reapply-design.md
+++ b/docs/superpowers/specs/2026-04-15-papermod-reapply-design.md
@@ -1,0 +1,132 @@
+# PaperMod Reapply Design
+
+## Problem
+
+The site currently runs on the Blowfish Hugo theme, but the desired direction is to reapply PaperMod while preserving the newer SEO, advertising, and site-level customizations that were added after the Blowfish migration.
+
+## Proposed Approach
+
+Use a hybrid migration:
+
+1. Install a fresh PaperMod theme source.
+2. Point Hugo at PaperMod.
+3. Port the current repo-owned customizations into PaperMod-compatible overrides.
+4. Keep monetization and SEO logic in the repository rather than inside the theme.
+
+This avoids dragging old PaperMod-era theme files back into the project while keeping the recent site behavior intact.
+
+## Scope
+
+In scope:
+
+- Add PaperMod as a fresh Hugo theme source.
+- Update theme selection and theme-specific Hugo configuration.
+- Preserve current site metadata, analytics, schema, and ad-related customizations.
+- Rework theme-coupled layout overrides so they integrate with PaperMod.
+- Validate core pages and post rendering under PaperMod.
+
+Out of scope:
+
+- Content rewrites.
+- URL or permalink restructuring.
+- New monetization features.
+- Unrelated refactors outside the theme migration path.
+
+## Architecture
+
+The migration should separate theme-owned concerns from site-owned concerns:
+
+- **Theme-owned:** PaperMod templates, assets, and defaults.
+- **Site-owned:** content, static assets, SEO metadata, schema partials, ad partials, analytics hooks, and targeted layout overrides.
+
+Hugo should render the site through this flow:
+
+`content + PaperMod defaults + repo overrides`
+
+This keeps the theme replaceable later while preserving the repo's business logic and SEO/monetization behavior.
+
+## Components
+
+### 1. Theme Source
+
+Add PaperMod as the active theme source under `themes/` and configure Hugo to use it.
+
+### 2. Theme Configuration
+
+Align Hugo configuration with PaperMod's expected parameters while retaining current site metadata and any non-theme-specific configuration already in use.
+
+### 3. Repo-Owned Customizations
+
+Preserve and reconnect:
+
+- Ad partials
+- Schema / structured data partials
+- Head / footer extension hooks
+- Analytics or publisher integrations that live in repo-owned templates
+
+These should remain outside the theme whenever possible.
+
+### 4. Template Overrides
+
+Update only the overrides needed to bridge current custom behavior into PaperMod, especially for:
+
+- Single post rendering
+- Shared page chrome
+- Partial insertion points required by ads or SEO hooks
+
+## Migration Flow
+
+1. Install fresh PaperMod.
+2. Switch active theme configuration from Blowfish to PaperMod.
+3. Compare current overrides against PaperMod's template structure.
+4. Reconnect repo-owned partials through PaperMod-compatible overrides.
+5. Remove or stop using Blowfish-specific assumptions in active templates/config.
+6. Build and inspect key pages.
+
+## Error Handling
+
+The main failure mode is template incompatibility between Blowfish and PaperMod.
+
+Rules for handling this:
+
+- Do not rely on silent fallbacks when a current partial no longer has a valid hook point.
+- Add explicit repo-owned overrides when PaperMod needs a different insertion path.
+- Keep migration changes localized to theme config and layout integration points.
+- Prefer visible, maintainable template wiring over fragile hacks.
+
+## Validation
+
+The migration is considered correct when:
+
+- Hugo builds successfully with PaperMod active.
+- Homepage, list pages, and single post pages render without missing-template errors.
+- Ad, schema, and extension partials still appear in the intended places.
+- Existing content continues to render without requiring Blowfish-specific front matter.
+
+## Testing Strategy
+
+Run existing project verification relevant to the Hugo site and inspect rendered output for:
+
+- Homepage
+- A list page
+- A representative single article page
+
+Testing should focus on behavior preservation rather than visual perfection during the migration step.
+
+## Risks
+
+- PaperMod may not expose the same insertion points as Blowfish.
+- Some current overrides may be tightly coupled to Blowfish markup.
+- Theme config keys may need reshaping to match PaperMod expectations.
+
+## Risk Mitigation
+
+- Start from a fresh PaperMod install instead of reviving stale theme files.
+- Keep SEO and monetization behavior in repo-owned partials and overrides.
+- Limit changes to the migration surface so regressions are easier to isolate.
+
+## Success Criteria
+
+- The site runs on PaperMod.
+- Current SEO and ad integrations remain functional.
+- The migration leaves a clean separation between theme code and repo-owned customizations.

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,71 @@
+{{- define "main" }}
+
+{{- if (and site.Params.profileMode.enabled .IsHome) }}
+{{- partial "index_profile.html" . }}
+{{- else }}
+
+{{- if not .IsHome | and .Title }}
+<header class="page-header">
+  {{- partial "breadcrumbs.html" . }}
+  <h1>{{ .Title }}</h1>
+  {{- if .Description }}
+  <div class="post-description">{{ .Description | markdownify }}</div>
+  {{- end }}
+</header>
+{{- end }}
+
+{{- if .Content }}
+<div class="md-content">
+  {{- if not (.Param "disableAnchoredHeadings") }}
+  {{- partial "anchored_headings.html" .Content -}}
+  {{- else }}{{ .Content }}{{ end }}
+</div>
+{{- end }}
+
+{{- $pages := union .RegularPages .Sections }}
+{{- if .IsHome }}
+{{- $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
+{{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true" }}
+{{- end }}
+
+{{- $paginator := .Paginate $pages }}
+{{- if and .IsHome site.Params.homeInfoParams (eq $paginator.PageNumber 1) }}
+{{- partial "home_info.html" . }}
+{{- end }}
+
+{{- range $index, $page := $paginator.Pages }}
+<article class="post-entry" data-pretext-card="true">
+  {{- $isHidden := (.Param "cover.hiddenInList") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" false "isHidden" $isHidden) }}
+  <header class="entry-header">
+    <h2 class="entry-hint-parent">{{ .Title }}</h2>
+  </header>
+  {{- if (ne (.Param "hideSummary") true) }}
+  <div class="entry-content">
+    <p data-pretext-scope="excerpt">{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
+  </div>
+  {{- end }}
+  {{- if not (.Param "hideMeta") }}
+  <footer class="entry-footer">
+    {{- partial "post_meta.html" . -}}
+  </footer>
+  {{- end }}
+  <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+</article>
+{{- end }}
+
+{{- if gt $paginator.TotalPages 1 }}
+<footer class="page-footer">
+  <nav class="pagination">
+    {{- if $paginator.HasPrev }}
+    <a class="prev" href="{{ $paginator.Prev.URL | absURL }}">«&nbsp;{{ i18n "prev_page" }}</a>
+    {{- end }}
+    {{- if $paginator.HasNext }}
+    <a class="next" href="{{ $paginator.Next.URL | absURL }}">{{ i18n "next_page" }}&nbsp;»</a>
+    {{- end }}
+  </nav>
+</footer>
+{{- end }}
+
+{{- end }}
+{{- end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,148 +1,65 @@
-{{ define "main" }}
-  {{ .Scratch.Set "scope" "single" }}
-  <article>
-    {{/* Hero */}}
-    {{ if .Params.showHero | default (site.Params.article.showHero | default false) }}
-      {{ $heroStyle := .Params.heroStyle }}
-      {{ if not $heroStyle }}{{ $heroStyle = site.Params.article.heroStyle }}{{ end }}
-      {{ $heroStyle := print "hero/" $heroStyle ".html" }}
-      {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
-        {{ partial $heroStyle . }}
-      {{ else }}
-        {{ partial "hero/basic.html" . }}
-      {{ end }}
-    {{ end }}
+{{- define "main" }}
+<article class="post-single">
+  <header class="post-header">
+    {{ partial "breadcrumbs.html" . }}
+    <h1 class="post-title">{{ .Title }}</h1>
+    {{- if .Description }}
+    <div class="post-description">{{ .Description }}</div>
+    {{- end }}
+    {{- if not (.Param "hideMeta") }}
+    <div class="post-meta">
+      {{- partial "post_meta.html" . -}}
+      {{- partial "translation_list.html" . -}}
+      {{- partial "edit_post.html" . -}}
+      {{- partial "post_canonical.html" . -}}
+    </div>
+    {{- end }}
+  </header>
 
-    {{/* Header */}}
-    <header id="single_header" class="mt-5 max-w-prose">
-      {{ if .Params.showBreadcrumbs | default (site.Params.article.showBreadcrumbs | default false) }}
-        {{ partial "breadcrumbs.html" . }}
-      {{ end }}
-      <h1 class="mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
-        {{ .Title | emojify }}
-      </h1>
-      <div class="mt-1 mb-6 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
-        {{ partial "article-meta/basic.html" (dict "context" . "scope" "single") }}
-      </div>
-      {{ if not (.Params.showAuthorBottom | default (site.Params.article.showAuthorBottom | default false)) }}
-        {{ template "SingleAuthor" . }}
-      {{ end }}
-    </header>
+  {{- $isHidden := (.Param "cover.hiddenInSingle") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" true "isHidden" $isHidden) }}
 
-    {{/* Body */}}
-    <section class="flex flex-col max-w-full mt-0 prose dark:prose-invert lg:flex-row">
-      {{ $enableToc := site.Params.article.showTableOfContents | default false }}
-      {{ $enableToc = .Params.showTableOfContents | default $enableToc }}
-      {{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
-      {{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
-      {{ if $showToc }}
-        <div class="order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
-          <div class="toc ps-5 print:hidden lg:sticky {{ $topClass }}">
-            {{ partial "toc.html" . }}
-          </div>
-        </div>
-      {{ end }}
+  {{- if templates.Exists "partials/ads-top.html" }}
+  <div class="post-ads post-ads-top">
+    {{ partial "ads-top.html" . }}
+  </div>
+  {{- end }}
 
+  {{- if (.Param "ShowToc") }}
+  {{- partial "toc.html" . }}
+  {{- end }}
 
-      <div class="min-w-0 min-h-0 max-w-fit">
-        {{ partial "series/series.html" . }}
+  {{- if .Content }}
+  <div class="post-content md-content">
+    {{- if not (.Param "disableAnchoredHeadings") }}
+    {{- partial "anchored_headings.html" .Content -}}
+    {{- else }}{{ .Content }}{{ end }}
+  </div>
+  {{- end }}
 
-        {{/* Ad: Above article content */}}
-        {{ if templates.Exists "partials/ads-top.html" }}
-          <div class="not-prose my-4 print:hidden">
-            {{ partial "ads-top.html" . }}
-          </div>
-        {{ end }}
+  {{- if templates.Exists "partials/ads-bottom.html" }}
+  <div class="post-ads post-ads-bottom">
+    {{ partial "ads-bottom.html" . }}
+  </div>
+  {{- end }}
 
-        <div class="article-content max-w-prose mb-20">
-          {{ .Content }}
+  <footer class="post-footer">
+    {{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
+    <ul class="post-tags">
+      {{- range ($.GetTerms $tags) }}
+      <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+      {{- end }}
+    </ul>
+    {{- if (.Param "ShowPostNavLinks") }}
+    {{- partial "post_nav_links.html" . }}
+    {{- end }}
+    {{- if (and site.Params.ShowShareButtons (ne .Params.disableShare true)) }}
+    {{- partial "share_icons.html" . -}}
+    {{- end }}
+  </footer>
 
-          {{/* Ad: Below article content */}}
-          {{ if templates.Exists "partials/ads-bottom.html" }}
-            <div class="not-prose my-6 print:hidden">
-              {{ partial "ads-bottom.html" . }}
-            </div>
-          {{ end }}
-
-          {{ $defaultReplyByEmail := site.Params.replyByEmail }}
-          {{ $replyByEmail := default $defaultReplyByEmail .Params.replyByEmail }}
-          {{ if $replyByEmail }}
-            <strong class="block mt-8">
-              <a
-                target="_blank"
-                class="m-1 rounded bg-neutral-300 p-1.5 text-neutral-700 hover:bg-primary-500 hover:text-neutral dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-primary-400 dark:hover:text-neutral-800"
-                href="mailto:{{ site.Params.Author.email }}?subject={{ replace (printf "Reply to %s" .Title) "\"" "'" }}">
-                {{ i18n "article.reply_by_email" | default "Reply by Email" }}
-              </a>
-            </strong>
-          {{ end }}
-        </div>
-        {{ if (.Params.showAuthorBottom | default (site.Params.article.showAuthorBottom | default false)) }}
-          {{ template "SingleAuthor" . }}
-        {{ end }}
-        {{ partial "series/series-closed.html" . }}
-        {{ partial "sharing-links.html" . }}
-        {{ partial "related.html" . }}
-      </div>
-    </section>
-
-    {{/* Footer */}}
-    <footer class="pt-8 max-w-prose print:hidden">
-      {{ partial "article-pagination.html" . }}
-      {{ if .Params.showComments | default (site.Params.article.showComments | default false) }}
-        {{ if templates.Exists "partials/comments.html" }}
-          <div class="pt-3">
-            <hr class="border-dotted border-neutral-300 dark:border-neutral-600">
-            <div class="pt-3">
-              {{ partial "comments.html" . }}
-            </div>
-          </div>
-        {{ else }}
-          {{ warnf "[BLOWFISH] Comments are enabled for %s but no comments partial exists." .File.Path }}
-        {{ end }}
-      {{ end }}
-    </footer>
-  </article>
-{{ end }}
-
-{{ define "SingleAuthor" }}
-  {{ $authorsData := site.Data.authors }}
-  {{ $taxonomies := site.Taxonomies.authors }}
-  {{ $baseURL := site.BaseURL }}
-  {{ $taxonomyLink := 0 }}
-  {{ $showAuthor := 0 }}
-  {{ $isAuthorBottom := (.Params.showAuthorBottom | default ( site.Params.article.showAuthorBottom | default false)) }}
-
-  {{ if not (strings.HasSuffix $baseURL "/") }}
-    {{ $baseURL = delimit (slice $baseURL "/") "" }}
-  {{ end }}
-
-  {{ if .Params.showAuthor | default (site.Params.article.showAuthor | default true) }}
-    {{ $showAuthor = 1 }}
-    {{ partial "author.html" . }}
-  {{ end }}
-
-  {{ range $author := .Page.Params.authors }}
-    {{ $authorData := index $authorsData $author }}
-    {{- if $authorData -}}
-      {{ range $taxonomyname, $taxonomy := $taxonomies }}
-        {{ if (eq $taxonomyname $author) }}
-          {{ $taxonomyLink = delimit (slice $baseURL "authors/" $author "/") "" }}
-        {{ end }}
-      {{ end }}
-
-      {{ $finalLink := $taxonomyLink }}
-      {{ $currentLang := site.Language.Lang }}
-      {{ if eq site.LanguagePrefix "" }}
-        {{ $finalLink = printf "%sauthors/%s/" $baseURL $author }}
-      {{ else }}
-        {{ $finalLink = printf "%s%s/authors/%s/" $baseURL $currentLang $author }}
-      {{ end }}
-      {{ partial "author-extra.html" (dict "context" . "data" $authorData "link" $finalLink) }}
-    {{- end -}}
-  {{ end }}
-
-  {{ if or $taxonomyLink $showAuthor }}
-    <div class="{{ cond $isAuthorBottom "mb-10" "mb-5" }}"></div>
-  {{ end }}
-{{ end }}
+  {{- if (.Param "comments") }}
+  {{- partial "comments.html" . }}
+  {{- end }}
+</article>
+{{- end }}

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -1,0 +1,1 @@
+{{ partial "extend-footer.html" . }}

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -1,1 +1,3 @@
 {{ partial "extend-footer.html" . }}
+{{ $pretext := resources.Get "js/pretext-enhance.js" | js.Build | fingerprint }}
+<script defer src="{{ $pretext.RelPermalink }}" integrity="{{ $pretext.Data.Integrity }}"></script>

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,0 +1,2 @@
+{{ partial "extend-head.html" . }}
+{{ partial "schema.html" . }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "classroom",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "classroom",
+      "dependencies": {
+        "@chenglou/pretext": "^0.0.5"
+      }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.5.tgz",
+      "integrity": "sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "classroom",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@chenglou/pretext": "^0.0.5"
+  }
+}


### PR DESCRIPTION
## Summary
- Migrate Hugo theme from Blowfish to PaperMod, preserving AdSense, SWG, schema.html, and utterances comments via hook bridges
- Add @chenglou/pretext runtime pipeline for consistent excerpt height on homepage/list cards
- PaperMod-compatible single.html override re-inserts ad partials above and below article content

## Test Plan
- [ ] `hugo` builds clean (478 pages, 0 errors)
- [ ] Homepage shows post cards with `data-pretext-scope="excerpt"` markers
- [ ] Article pages include AdSense ads, SWG script, structured data (ld+json), and comments partial
- [ ] Search page works at `/search/`
- [ ] Theme toggle (light/dark/auto) functions correctly
- [ ] Pretext JS bundle loads with SRI integrity hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)